### PR TITLE
поправил представления контекстов в SmartAnts

### DIFF
--- a/src/main/resources/metamodel/dochub/entities/contexts/smartants.yaml
+++ b/src/main/resources/metamodel/dochub/entities/contexts/smartants.yaml
@@ -20,13 +20,16 @@ entities:
               $keys()[0]: {
                 "title": $.*.title,
                 "symbol":
-                    /* Если это актор, то используем встроенный символ */
-                    $.*.entity = "actor" ? "user" : (
-                      /* Если спекты не указаны, выводится стандартный символ системы */
-                      $count($.*.aspects) = 0 
-                      ? "system"
-                      /* Иначе используем сгенерированные символы */
-                      : "symbol-" & $keys()[0] 
+                    /* для boundary символ не нужен */
+                    $.*.entity = "boundary" ? null : (
+                      /* Если это актор, то используем встроенный символ */
+                      $.*.entity = "actor" ? "user" : (
+                        /* Если аспекты не указаны, выводится стандартный символ системы */
+                        $count($.*.aspects) = 0 
+                        ? "system"
+                        /* Иначе используем сгенерированные символы */
+                        : "symbol-" & $keys()[0] 
+                      )
                     )
               }
             }
@@ -36,12 +39,14 @@ entities:
       # Генерирует символ для элементов диаграммы
       # Входящие параметры:
       #   manifest    - данные архитектуры
+      #   components  - компоненты, для которых генерируются символы
       #   componentId - идентификатор компонента
       makeSASymbol: >
         (
           /* Обрабатываем входящие параметры */
           $manifest := manifest;
-          $component := $lookup($manifest.components, componentId);
+          $components := components;
+          $component := $lookup($components, componentId);
           $defConfig := $manifest.entities.contexts.config;
         
           /* Получаем высоту строки аспекта */
@@ -95,14 +100,16 @@ entities:
         (
           /* Обрабатываем входящие параметры */
           $manifest := manifest;
+          $components := components;
           $merge(components.$spread().(
             $eval($manifest.entities.contexts.api.makeSASymbol, {
               "manifest": $manifest,
+              "components": $components,
               "componentId": $keys()[0]
             })
           ));
         )
-    # Представления контекстов в PlantUML
+    # Представления контекстов в SmartAnts
     presentations:
       smartants:
         title: Представление в SmartAnts
@@ -128,13 +135,12 @@ entities:
             $defFunctions := $manifest.entities.contexts.api;
 
             /* Получаем все компоненты входящие в контекст */
-            $components := $eval($defFunctions.fetchComponents, {
+            $components := $eval($defFunctions.fetchComponents, $merge([$params, {
               "manifest": $manifest,
               "contextId": $id,
               "extra-links": $isExtraLinks,
               "componentId": $params.componentId
-            });
-
+            }]));
             /* Строим из компонентов ноды */
             $nodes := $eval($defFunctions.makeSANodes, {
               "manifest": $manifest,
@@ -158,8 +164,14 @@ entities:
             };
             /* Готовим данные для передачи в шаблон */
             {
+              "config": {
+                "distance": 100,
+                "trackWidth": 20,
+                "lineWidthLimit": 5,
+                "lineOpacity": 0.5
+              },
               "nodes": $nodes,
-              "links": $links,
+              "links": [$links],
               "symbols": $symbols
             }
           )


### PR DESCRIPTION
На всякий случай, если ты, вдруг, не копируешь каждый раз метамодель. Чтобы не забыть.